### PR TITLE
Cache intermediate build artifacts

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -16,7 +16,7 @@ mod download;
 mod index;
 mod storage;
 
-use std::fs;
+use std::{fs, env};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use structopt::StructOpt;
@@ -60,6 +60,7 @@ fn main() -> Result<(), Error> {
     fs::copy("storage", &download_dir.join("storage"))?;
 
     println!("Compiling WASM module using wasm-pack");
+    env::set_var("CARGO_TARGET_DIR", env::current_dir()?.join("tinysearch_build"));
     wasm_pack(&download_dir, &out_path)?;
 
     if opt.optimize {


### PR DESCRIPTION
With this change the target directory will be moved to $PWD/tinysearch_build by setting $CARGO_TARGET_DIR before calling wasm-pack.
This allows cargo to find the intermediate build artifacts of the previous build instead of discarding them.
On my machine this decreased the build time for fixtures/index.json from 37.58s to 2.62s on subsequent builds.