### PR TITLE
Removed usage of HashMap and HashSet

### DIFF
--- a/bin/src/storage.rs
+++ b/bin/src/storage.rs
@@ -19,7 +19,7 @@ pub fn gen(posts: Posts) -> Result<(), Error> {
     Ok(())
 }
 
-fn build(posts: Posts) -> Result<HashMap<PostId, CuckooFilter<DefaultHasher>>, Error> {
+fn build(posts: Posts) -> Result<Vec<(PostId, CuckooFilter<DefaultHasher>)>, Error> {
     let posts = prepare_posts(posts);
     generate_filters(posts)
 }
@@ -33,7 +33,7 @@ fn cleanup(s: String) -> String {
 #[no_mangle]
 pub fn generate_filters(
     posts: HashMap<PostId, String>,
-) -> Result<HashMap<PostId, CuckooFilter<DefaultHasher>>, Error> {
+) -> Result<Vec<(PostId, CuckooFilter<DefaultHasher>)>, Error> {
     // Create a dictionary of {"post name": "lowercase word set"}. split_posts =
     // {name: set(re.split("\W+", contents.lower())) for name, contents in
     // posts.items()}
@@ -62,7 +62,7 @@ pub fn generate_filters(
     // words in each. We could do more things, like stemming, removing common
     // words (a, the, etc), but we’re going for naive, so let’s just create the
     // filters for now:
-    let mut filters = HashMap::new();
+    let mut filters = Vec::new();
     for (name, words) in split_posts {
         // Adding some more padding to the capacity because sometimes there is an error
         // about not having enough space. Not sure why that happens, though.
@@ -74,7 +74,7 @@ pub fn generate_filters(
         for word in name.0.split_whitespace() {
             filter.add(&cleanup(strip_markdown(word)))?;
         }
-        filters.insert(name, filter);
+        filters.push((name, filter));
     }
     trace!("Done");
     Ok(filters)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -2,9 +2,8 @@
 extern crate lazy_static;
 
 use std::cmp::Reverse;
-use std::collections::HashSet;
 use std::error::Error;
-use tinysearch_shared::{Filters, Score, Storage, PostId};
+use tinysearch_shared::{Filters, PostId, Score, Storage};
 use wasm_bindgen::prelude::*;
 
 #[global_allocator]
@@ -21,8 +20,7 @@ lazy_static! {
 
 #[wasm_bindgen]
 pub fn search(query: String, num_results: usize) -> JsValue {
-    let search_terms: HashSet<String> =
-        query.split_whitespace().map(|s| s.to_lowercase()).collect();
+    let search_terms: Vec<String> = query.split_whitespace().map(|s| s.to_lowercase()).collect();
 
     let mut matches: Vec<(&PostId, u32)> = FILTERS
         .iter()

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,11 +3,10 @@ use std::convert::From;
 use tinysearch_cuckoofilter::{self, CuckooFilter, ExportedCuckooFilter};
 
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
 
 pub type PostId = (String, String);
-pub type Filters = HashMap<PostId, CuckooFilter<DefaultHasher>>;
-type ExportedFilters = HashMap<PostId, ExportedCuckooFilter>;
+pub type Filters = Vec<(PostId, CuckooFilter<DefaultHasher>)>;
+type ExportedFilters = Vec<(PostId, ExportedCuckooFilter)>;
 
 pub struct Storage {
     pub filters: Filters,
@@ -20,16 +19,16 @@ impl From<Filters> for Storage {
 }
 
 pub trait Score {
-    fn score(&self, terms: &HashSet<String>) -> u32;
+    fn score<A: AsRef<str>, I: IntoIterator<Item = A>>(&self, terms: I) -> u32;
 }
 
 // the score is the number of terms from the query that contained in the current
 // filter
 impl Score for CuckooFilter<DefaultHasher> {
-    fn score(&self, terms: &HashSet<String>) -> u32 {
+    fn score<A: AsRef<str>, I: IntoIterator<Item = A>>(&self, terms: I) -> u32 {
         terms
-            .iter()
-            .filter(|term| self.contains(&term.to_lowercase()))
+            .into_iter()
+            .filter(|term| self.contains(term.as_ref()))
             .count() as u32
     }
 }


### PR DESCRIPTION
At no point they were actually used as Key-Value-Stores, so i just replaced them with Vec.
This should improve performance and decrease binary size by a bit.
I have not tested either though, mainly because no automated benchmarks exist.